### PR TITLE
Add support for callback urls in verification sessions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
 
-    compile 'org.irmacard.api:irma_api_common:0.4.0'
+    compile 'org.irmacard.api:irma_api_common:0.6.1'
 
     testCompile "junit:junit:4.11"
     testCompile 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jetty:2.19'

--- a/src/main/java/org/irmacard/api/web/VerificationResource.java
+++ b/src/main/java/org/irmacard/api/web/VerificationResource.java
@@ -257,7 +257,7 @@ public class VerificationResource {
     // TODO: move to some kind of 'util class'?
     private static void sendProofResult(URL url, String jwt) {
         HttpTransport transport = new NetHttpTransport.Builder().build();
-        HttpContent content = new ByteArrayContent("application/json", ("{ \"proof\": \"" + jwt + "\" }").getBytes());
+        HttpContent content = new ByteArrayContent("text/plain", jwt.getBytes());
 
         new Thread() {
             @Override

--- a/src/test/java/org/irmacard/api/web/VerificationTest.java
+++ b/src/test/java/org/irmacard/api/web/VerificationTest.java
@@ -320,6 +320,7 @@ public class VerificationTest extends JerseyTest {
 
 	@Test(expected=NotAuthorizedException.class)
 	public void wrongJwtKeyTest() throws KeyManagementException {
+		ApiConfiguration.getInstance().allow_unsigned_verification_requests = false;
 		createSession(System.currentTimeMillis() / 1000,
 				ApiConfiguration.instance.getPrivateKey("sk.der"));
 	}


### PR DESCRIPTION
To reduce complexity at the service provider's side, it can sometimes be desired to let the `irma_api_server` call a url at the service provider's website, instead of letting the service provider 'wait' for a disclosure result on a websocket/http poll.

I also added a small fix for a failing unit test.